### PR TITLE
「パスワードを忘れた方」の表示のみ追加

### DIFF
--- a/app/assets/stylesheets/modules/login/_log_in.scss
+++ b/app/assets/stylesheets/modules/login/_log_in.scss
@@ -23,7 +23,7 @@
       margin: 0 auto;
       width: 456px;
       background: $white;
-      padding: 40px 0 64px;
+      padding: 40px 0 10px;
       text-align: center;
 
       &__button {
@@ -148,6 +148,13 @@
         transition: all ease-out .3s;
       }
     }
+  }
+
+  .link {
+    display: block;
+    margin-top: 40px;
+    text-align: left;
+    color: $cyan;
   }
 }
 

--- a/app/views/login/log_in.html.haml
+++ b/app/views/login/log_in.html.haml
@@ -36,5 +36,9 @@
           .contents-field
             .contents-field__button
               = f.submit "ログイン", class: "form__submit"
+            .text-left
+              %p.text__password
+                = link_to "https://www.mercari.com/jp/password/reset/start/", target: :_blank , class:"link" do
+                  パスワードをお忘れの方
 
 = render partial: "signup/sign_up_footer"


### PR DESCRIPTION
# What
ログイン画面(log_in)において「パスワードを忘れた方」の表示を追加。

# Why
公式では上記表示があったが記載漏れであったため。


※なお、リンク先は便宜上公式版に飛ぶように設定しています。
　時間があったら追って作成（特に現段階では作成する必要もないと思われるため）。