### PR TITLE
ログイン・ログアウト時のボタン切り替え

### DIFF
--- a/app/assets/javascripts/toppage/header.js
+++ b/app/assets/javascripts/toppage/header.js
@@ -1,5 +1,7 @@
 var hover_blue = 'rgb(0, 149, 238)'
 var hover_black = 'rgb(0, 0, 0)'
+var white_grey = 'rgb(204, 204, 204)'
+var black_grey = '#333'
 
 //カテゴリー検索
 document.addEventListener('turbolinks:load', function(){
@@ -59,5 +61,21 @@ document.addEventListener('turbolinks:load', function(){
     $(".lower__left__brand__box").hide(); 
     $('.lower__left__brand_search').css('color', hover_black); 
 
+  });
+});
+
+//ホバー時にfontawsomeと文言の色を変更
+$(document).ready(function() {
+
+  $('.lower__right_li').hover(function() {
+
+    $(this).find('.fa').css('color',  hover_blue); 
+    $(this).css('color', hover_blue); 
+
+  }, function() {
+    
+    $(this).find('.fa').css('color',  white_grey); 
+    $(this).css('color',  black_grey); 
+    
   });
 });

--- a/app/assets/stylesheets/modules/top/_header.scss
+++ b/app/assets/stylesheets/modules/top/_header.scss
@@ -281,65 +281,64 @@
           }
         }
 
-        //レビュー対象外
-        // &__nice {
-        //   @include top_header_list;
-        //   display: none;
-        //   padding-left: 0px;
+        &__nice {
+          @include top_header_list;
+          display: none;
+          padding-left: 0px;
 
-        //   @media (min-width: 1068px) {
-        //     display: block;
-        //   }
+          @media (min-width: 1068px) {
+            display: block;
+          }
 
-        //   &_link {
-        //     @include top_header_list_link;
+          &_link {
+            @include top_header_list_link;
             
-        //     &_img {
-        //       @include top_header_list_link_img; 
-        //     }   
-        //   }
-        // }
+            &_img {
+              @include top_header_list_link_img; 
+            }   
+          }
+        }
   
 
-        // &__news {
-        //   @include top_header_list;
+        &__news {
+          @include top_header_list;
 
-        //   &_link {
-        //     @include top_header_list_link;
+          &_link {
+            @include top_header_list_link;
 
-        //     &_img {
-        //       @include top_header_list_link_img;
-        //     }
-        //   }
-        // }
+            &_img {
+              @include top_header_list_link_img;
+            }
+          }
+        }
 
-        // &__to-do {
-        //   @include top_header_list;
+        &__to-do {
+          @include top_header_list;
 
-        //   &_link {
-        //     @include top_header_list_link;
+          &_link {
+            @include top_header_list_link;
 
-        //     &_img {              
-        //       @include top_header_list_link_img;
-        //     }
-        //   }
-        // }
+            &_img {              
+              @include top_header_list_link_img;
+            }
+          }
+        }
 
-        // &__mypage {
-        //   @include top_header_list;
-        //   padding-right: 0px;
+        &__mypage {
+          @include top_header_list;
+          padding-right: 0px;
 
-        //   &_link {
-        //     @include top_header_list_link;
+          &_link {
+            @include top_header_list_link;
 
-        //     &_img {
-        //       margin-right: 10px;
-        //       width: 32px;
-        //       border-radius: 50%;
-        //       overflow: hidden;
-        //     }
-        //   }
-        // }
+            &_img {
+              margin-right: 10px;
+              width: 32px;
+              border-radius: 50%;
+              overflow: hidden;
+            }
+          }
+        }
 
       }
     }

--- a/app/assets/stylesheets/modules/top/_header_responsive.scss
+++ b/app/assets/stylesheets/modules/top/_header_responsive.scss
@@ -65,49 +65,49 @@
           }
         }
       }
-    //レビュー対象外
-      // .upper_right_in {
-      //   align-items: center;
-      //   display: flex;
 
-      //   .news {
+      .upper_right_in {
+        align-items: center;
+        display: flex;
 
-      //     &_link {
-      //       @include top_header_responsive_upper_right_link;
+        .news {
 
-      //       .fa {
-      //         @include top_header_responsive_upper_right_link_fa;
-      //         width: 18px;
-      //       }
-      //     }
-      //   }
+          &_link {
+            @include top_header_responsive_upper_right_link;
 
-      //   .to-do {
-      //     margin-left: 16px;
+            .fa {
+              @include top_header_responsive_upper_right_link_fa;
+              width: 18px;
+            }
+          }
+        }
 
-      //     &_link {
-      //       @include top_header_responsive_upper_right_link;
+        .to-do {
+          margin-left: 16px;
 
-      //       .fa {
-      //         @include top_header_responsive_upper_right_link_fa;
-      //         width: 22px;
-      //       }
-      //     }
-      //   }
+          &_link {
+            @include top_header_responsive_upper_right_link;
 
-      //   .mypage-img {
-      //     margin-left: 16px;
+            .fa {
+              @include top_header_responsive_upper_right_link_fa;
+              width: 22px;
+            }
+          }
+        }
 
-      //     &_link {
-      //       @include top_header_responsive_upper_right_link;
+        .mypage-img {
+          margin-left: 16px;
 
-      //       &_img {
-      //         border-radius: 50%;
-      //         overflow: hidden;
-      //       }
-      //     }
-      //   }
-      // }
+          &_link {
+            @include top_header_responsive_upper_right_link;
+
+            &_img {
+              border-radius: 50%;
+              overflow: hidden;
+            }
+          }
+        }
+      }
     }
 
     .middle {

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -237,8 +237,31 @@
                 = link_to "アディダス", "" , class: "brand__list__item_link"
               %li.brand__list__item
                 = link_to "ブランド一覧", "" , class: "brand__list__item_link"
-      .lower__right
-        .lower__right__sign-up
-          = link_to "新規会員登録", "", class: "lower__right__sign-up_link"
-        .lower__right__login
-          = link_to "ログイン", "", class: "lower__right__login_link"
+
+        - if user_signed_in?
+          %ul.lower__right
+          %li.lower__right__nice.lower__right_li
+            = link_to  "", class: "lower__right__nice_link" do
+              .lower__right__nice_link_img
+                %i.fa.fa-heart
+              いいね！一覧
+          %li.lower__right__news.lower__right_li
+            = link_to  "", class: "lower__right__news_link" do
+              .lower__right__news_link_img
+                %i.fa.fa-bell
+              お知らせ
+          %li.lower__right__to-do.lower__right_li
+            = link_to  "", class: "lower__right__to-do_link" do
+              .lower__right__to-do_link_img
+                %i.fa.fa-check
+              やることリスト
+          %li.lower__right__mypage.lower__right_li
+            = link_to  "", class: "lower__right__mypage_link" do
+              = image_tag("https://static.mercdn.net/thumb/members/158882622.jpg?1572265146", class: "lower__right__mypage_link_img")
+              マイページ
+      - else
+        .lower__right
+          .lower__right__sign-up
+            = link_to "新規会員登録", "", class: "lower__right__sign-up_link"
+          .lower__right__login
+            = link_to "ログイン", "", class: "lower__right__login_link"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -238,27 +238,27 @@
               %li.brand__list__item
                 = link_to "ブランド一覧", "" , class: "brand__list__item_link"
 
-        - if user_signed_in?
-          %ul.lower__right
-          %li.lower__right__nice.lower__right_li
-            = link_to  "", class: "lower__right__nice_link" do
-              .lower__right__nice_link_img
-                %i.fa.fa-heart
-              いいね！一覧
-          %li.lower__right__news.lower__right_li
-            = link_to  "", class: "lower__right__news_link" do
-              .lower__right__news_link_img
-                %i.fa.fa-bell
-              お知らせ
-          %li.lower__right__to-do.lower__right_li
-            = link_to  "", class: "lower__right__to-do_link" do
-              .lower__right__to-do_link_img
-                %i.fa.fa-check
-              やることリスト
-          %li.lower__right__mypage.lower__right_li
-            = link_to  "", class: "lower__right__mypage_link" do
-              = image_tag("https://static.mercdn.net/thumb/members/158882622.jpg?1572265146", class: "lower__right__mypage_link_img")
-              マイページ
+      - if user_signed_in?
+        %ul.lower__right
+        %li.lower__right__nice.lower__right_li
+          = link_to  "", class: "lower__right__nice_link" do
+            .lower__right__nice_link_img
+              %i.fa.fa-heart
+            いいね！一覧
+        %li.lower__right__news.lower__right_li
+          = link_to  "", class: "lower__right__news_link" do
+            .lower__right__news_link_img
+              %i.fa.fa-bell
+            お知らせ
+        %li.lower__right__to-do.lower__right_li
+          = link_to  "", class: "lower__right__to-do_link" do
+            .lower__right__to-do_link_img
+              %i.fa.fa-check
+            やることリスト
+        %li.lower__right__mypage.lower__right_li
+          = link_to  "", class: "lower__right__mypage_link" do
+            = image_tag("https://static.mercdn.net/thumb/members/158882622.jpg?1572265146", class: "lower__right__mypage_link_img")
+            マイページ
       - else
         .lower__right
           .lower__right__sign-up

--- a/app/views/layouts/_header_responsive.html.haml
+++ b/app/views/layouts/_header_responsive.html.haml
@@ -5,9 +5,21 @@
         .link
           =image_tag("https://web-jp-assets.mercdn.net/_next/static/images/logo-acdd90ac4f472d5a6f7a330d33ab1225.svg", class: "logo")
 
-      .upper_right
-        = link_to "新規会員", "", class: "sign-up"
-        = link_to "ログイン", "", class: "login"
+      - if user_signed_in?
+        .upper_right_in
+          .news
+            = link_to "", class: "news_link" do
+              %i.fa.fa-bell
+          .to-do
+            = link_to "", class: "to-do_link" do
+              %i.fa.fa-check
+          .mypage-img
+            = link_to "", class: "mypage-img_link" do
+              = image_tag("https://static.mercdn.net/thumb/members/158882622.jpg?1572265146", class: "mypage-img_link_img")
+      - else
+        .upper_right
+          = link_to "新規会員", "", class: "sign-up"
+          = link_to "ログイン", "", class: "login"
 
     .middle
       = form_tag "", method: :get, class: "search__form" do


### PR DESCRIPTION
# WHAT
ログイン・ログアウトによって、ボタンの表示を切り替える
　ログイン時　　→いいね！一覧、お知らせ、やることリスト、マイページ
　ログアウト時　→ログイン、新規登録

# WHY
ログイン・ログアウトで異なる機能を提供するため

[キャプチャ](https://gyazo.com/13274b69dd6bc21267acd5046bf64293)
[レスポンシブ](https://gyazo.com/eebbe64e2acaa4f296e49450213cd6ba)