### PR TITLE
[WIP]商品購入確認ページのビューの作成

### DIFF
--- a/app/assets/stylesheets/config/_color.scss
+++ b/app/assets/stylesheets/config/_color.scss
@@ -1,5 +1,5 @@
 $white: #fff;
-$light-grey: #f5f5f5;
+$light-grey-f5: #f5f5f5;
 $cyan: #0099E8;
 $grey: #ccc;
 $red: #EA352D;

--- a/app/assets/stylesheets/mixin/mixin.scss
+++ b/app/assets/stylesheets/mixin/mixin.scss
@@ -182,3 +182,8 @@
   line-height: $length;
   width: $length;
 }
+
+@mixin purchase-inner {
+  max-width: 320px;
+  margin: 0 auto;
+}

--- a/app/assets/stylesheets/modules/merchadise/_detail.scss
+++ b/app/assets/stylesheets/modules/merchadise/_detail.scss
@@ -164,6 +164,10 @@
         background-color: #E52017;
       }
 
+      &__link {
+        display: block;
+      }
+
       @media screen and (max-width: 768px) {
         height: 56px;
         font-size: 14px;

--- a/app/assets/stylesheets/modules/purchase/delivery.scss
+++ b/app/assets/stylesheets/modules/purchase/delivery.scss
@@ -1,0 +1,31 @@
+.purchase {
+  .delivery {
+    margin-top: 40px;
+    padding: 24px 12.5% 0;
+    border-top: 1px solid $light-grey-f5;
+
+    &__inner {
+      @include purchase-inner;
+
+      &__header {
+        font-weight: 700;
+      }
+
+      &__destination {
+        margin-top: 8px;
+        line-height: 1.4;
+      }
+
+      &__change {
+        margin-top: 8px;
+        display: block;
+        color: $cyan;
+        text-align: right;
+
+        &__icon {
+          margin-left: 8px;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/purchase/item-container.scss
+++ b/app/assets/stylesheets/modules/purchase/item-container.scss
@@ -1,0 +1,110 @@
+.purchase {
+  width: 700px;
+  margin: auto;
+  background-color: $white;
+
+  @media screen and (max-width: 768px) {
+    width: auto;
+  }
+
+  &__header {
+    padding: 16px;
+    text-align: center;
+    font-size: 22px;
+    font-weight: 700;
+    line-height: 33px;
+  }
+
+  .item-container {
+    padding: 24px 12.5% 0;
+    border-top: 1px solid $light-grey-f5;
+
+    &__inner {
+      @include purchase-inner;
+      display: flex;
+      flex-wrap: wrap;
+      text-align: center;
+      
+      &__item {
+        box-sizing: border-box;
+        width: 100%;
+        font-size: 0;
+        
+        &__image-box {
+          display: inline-block;
+          vertical-align: top;
+  
+          &__image {
+            width: 64px;
+          }
+        }
+        
+        &__name {
+          line-height: 24px;
+          box-sizing: border-box;
+          width: calc(100% - 80px);
+          margin-left: 16px;
+          text-align: left;
+          font-size: 14px;
+          display: inline-block;
+          vertical-align: top;
+        }
+      }
+
+      .purchase-form {
+        width: 100%;
+
+        &__price {
+          margin-top: 8px;
+          line-height: 1.5;
+          font-size: 22px;
+          font-weight: 600;
+
+          span {
+            font-weight: 400;
+            font-size: 14px;
+            margin-left: 8px;
+          }
+        }
+
+        &__point {
+          margin-top: 16px;
+          background-color: $grey;
+          padding: 16px;
+        }
+
+        &__payment {
+          font-weight: 600;
+          display: table;
+          width: 100%;
+          
+          &__text {
+            display: table-cell;
+            padding: 16px 0;
+            text-align: left;
+            font-size: 18px;
+            line-height: 18px;
+            vertical-align: middle;
+          }
+
+          &__price {
+            display: table-cell;
+            padding: 16px 0;
+            text-align: right;
+            font-size: 28px;
+            line-height: 28px;
+            vertical-align: middle;
+          }
+        }
+
+        &__button {
+          margin-top: 8px;
+          background-color: $red;
+          color: $white;
+          line-height: 48px;
+          font-weight: 600;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/purchase/payment.scss
+++ b/app/assets/stylesheets/modules/purchase/payment.scss
@@ -1,0 +1,32 @@
+.purchase {
+  .payment {
+    margin-top: 40px;
+    padding: 24px 12.5% 40px;
+    border-top: 1px solid $light-grey-f5;
+
+    &__inner {
+      @include purchase-inner;
+
+      &__header {
+        font-weight: 700;
+      }
+
+      &__card-info {
+        margin-top: 8px;
+        line-height: 1.4;
+      }
+
+      &__card-logo {
+        width: 49px;
+        height: 15px;
+      }
+
+      &__change {
+        margin-top: 8px;
+        display: block;
+        color: $cyan;
+        text-align: right;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the purchase controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the purchase controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,7 +1,8 @@
 class PurchaseController < ApplicationController
 
   def index
-    
+    # TODO 商品詳細バックエンドマージ後、findの部分をparams[merchandise.id]へ
+    @merchandise = Merchandise.find(1)
   end
 
   def create

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,0 +1,10 @@
+class PurchaseController < ApplicationController
+
+  def index
+    
+  end
+
+  def create
+    
+  end
+end

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,8 +1,9 @@
 class PurchaseController < ApplicationController
 
   def index
-    # TODO 商品詳細バックエンドマージ後、findの部分をparams[merchandise.id]へ
-    @merchandise = Merchandise.find(1)
+    @merchandise = Merchandise.find(params[:merchandise_id])
+    # こちらはcurrent_userにする予定
+    @user = User.find(1)
   end
 
   def create

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,6 +1,10 @@
 class Address < ApplicationRecord
   belongs_to :user
 
+  def get_full_address
+    self.prefecture.name + self.city + self.number
+  end
+
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,8 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :purchases, dependent: :destroy
   has_many :evaluations, dependent: :destroy
+
+  def get_full_name
+    self.first_name + ' ' + self.last_name    
+  end
 end

--- a/app/views/merchandises/show.html.haml
+++ b/app/views/merchandises/show.html.haml
@@ -128,7 +128,7 @@
           着払い
 
     .buy-button
-      = link_to "#" do
+      = link_to merchandise_purchase_index_path(@merchandise), class: 'buy-button__link' do
         購入画面に進む
     
     .item-description

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -7,21 +7,25 @@
     .item-container__inner
       .item-container__inner__item
         .item-container__inner__item__image-box
-          = image_tag 'https://placehold.jp/150x150.png', class: 'item-container__inner__item__image-box__image'
+          = image_tag "#{@merchandise.exhibit.exhibit_images[0].image}", class: 'item-container__inner__item__image-box__image'
         %p.item-container__inner__item__name
-          サンプル品サンプルサンプルサンプルサンプルサンプル品
+          = @merchandise.name
       .purchase-form
         .purchase-form__price
-          = "¥#{2500.to_s(:delimited)}"
-          %span
-            送料込み
+          = "¥#{@merchandise.price.to_s(:delimited)}"
+          - if @merchandise.delivery.shipping_charge_id == 1
+            %span
+              送料込み
+          - elsif @merchandise.delivery.shipping_charge_id == 2
+            %span
+              着払い
         .purchase-form__point
           ポイントはありません
         .purchase-form__payment
           .purchase-form__payment__text
             支払い金額
           .purchase-form__payment__price
-            = "¥#{2500.to_s(:delimited)}"
+            = "¥#{@merchandise.price.to_s(:delimited)}"
         .purchase-form__button
           購入する
   
@@ -30,11 +34,11 @@
       %h3.delivery__inner__header
         配送先
       .delivery__inner__destination
-        〒000-000
+        = "〒#{User.find(1).address.postal_code}"
         %br/
-        埼玉県〇〇市00-0
+        = User.find(1).address.get_full_address
         %br/
-        テスト 太郎
+        = User.find(1).first_name + ' ' + User.find(1).last_name
       = link_to '#', class: 'delivery__inner__change' do
         %span
           変更する

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,52 +1,58 @@
 = render partial: 'exhibit/header'
 
 .purchase
-  %h2.header
+  %h2.purchase__header
+    購入内容の確認
   .item-container
-    .item-container__item
-      .item-container__item__left
-      = image_tag 'https://placehold.jp/150x150.png', class: 'item-container__item__image'
-      .item-container__item__right
-        .item-container__item__right__name
-          サンプル品
-        .item-container__item__right__price
+    .item-container__inner
+      .item-container__inner__item
+        .item-container__inner__item__image-box
+          = image_tag 'https://placehold.jp/150x150.png', class: 'item-container__inner__item__image-box__image'
+        %p.item-container__inner__item__name
+          サンプル品サンプルサンプルサンプルサンプルサンプル品
+      .purchase-form
+        .purchase-form__price
           = "¥#{2500.to_s(:delimited)}"
           %span
             送料込み
-      .item-container__point
-      .item-container__payment
-        .item-container__payment__text
-          支払い金額
-        .item-container__payment__price
-          = "¥#{2500.to_s(:delimited)}"
-      .item-container__purchase-button
+        .purchase-form__point
+          ポイントはありません
+        .purchase-form__payment
+          .purchase-form__payment__text
+            支払い金額
+          .purchase-form__payment__price
+            = "¥#{2500.to_s(:delimited)}"
+        .purchase-form__button
+          購入する
   
   .delivery
-    %h3.delivery__header
-    .delivery__destination
-      〒000-000
-      %br/
-      埼玉県〇〇市00-0
-      %br/
-      テスト 太郎
-    = link_to '#', class: 'delivery__change' do
-      %span
-        変更する
-      = fa_icon 'chevron-right'
+    .delivery__inner
+      %h3.delivery__inner__header
+        配送先
+      .delivery__inner__destination
+        〒000-000
+        %br/
+        埼玉県〇〇市00-0
+        %br/
+        テスト 太郎
+      = link_to '#', class: 'delivery__inner__change' do
+        %span
+          変更する
+        = fa_icon 'chevron-right', class: 'delivery__inner__change__icon'
 
   .payment
-    %h3.payment__header
-      支払い方法
-    .payment__card-info
-      *********0000
-      %br/
-      12/99
-      %br/
-      = image_tag('visa.svg', class: 'card_logo')
-    = link_to '#', class: 'payment__change' do
-      %span
-        変更する
-      = fa_icon 'chevron-right'
+    .payment__inner
+      %h3.payment__inner__header
+        支払い方法
+      .payment__inner__card-info
+        *********0000
+        %br/
+        12/99
+      = image_tag('visa.svg', class: 'payment__inner__card-logo')
+      = link_to '#', class: 'payment__inner__change' do
+        %span
+          変更する
+        = fa_icon 'chevron-right'
 
 
 = render partial: 'exhibit/footer'

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -34,11 +34,11 @@
       %h3.delivery__inner__header
         配送先
       .delivery__inner__destination
-        = "〒#{User.find(1).address.postal_code}"
+        = "〒#{@user.address.postal_code}"
         %br/
-        = User.find(1).address.get_full_address
+        = @user.address.get_full_address
         %br/
-        = User.find(1).first_name + ' ' + User.find(1).last_name
+        = @user.get_full_name
       = link_to '#', class: 'delivery__inner__change' do
         %span
           変更する

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,0 +1,52 @@
+= render partial: 'exhibit/header'
+
+.purchase
+  %h2.header
+  .item-container
+    .item-container__item
+      .item-container__item__left
+      = image_tag 'https://placehold.jp/150x150.png', class: 'item-container__item__image'
+      .item-container__item__right
+        .item-container__item__right__name
+          サンプル品
+        .item-container__item__right__price
+          = "¥#{2500.to_s(:delimited)}"
+          %span
+            送料込み
+      .item-container__point
+      .item-container__payment
+        .item-container__payment__text
+          支払い金額
+        .item-container__payment__price
+          = "¥#{2500.to_s(:delimited)}"
+      .item-container__purchase-button
+  
+  .delivery
+    %h3.delivery__header
+    .delivery__destination
+      〒000-000
+      %br/
+      埼玉県〇〇市00-0
+      %br/
+      テスト 太郎
+    = link_to '#', class: 'delivery__change' do
+      %span
+        変更する
+      = fa_icon 'chevron-right'
+
+  .payment
+    %h3.payment__header
+      支払い方法
+    .payment__card-info
+      *********0000
+      %br/
+      12/99
+      %br/
+      = image_tag('visa.svg', class: 'card_logo')
+    = link_to '#', class: 'payment__change' do
+      %span
+        変更する
+      = fa_icon 'chevron-right'
+
+
+= render partial: 'exhibit/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :merchandises, only: [:index, :show] do
     resources :comments, only: [:create, :new]
     resources :likes, only: [:create, :destroy]
+    resources :purchase, only: [:index, :create]
   end
   resources :exhibit, only: [:index]
 

--- a/spec/controllers/purchase_controller_spec.rb
+++ b/spec/controllers/purchase_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PurchaseController, type: :controller do
+
+end

--- a/spec/helpers/purchase_helper_spec.rb
+++ b/spec/helpers/purchase_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PurchaseHelper. For example:
+#
+# describe PurchaseHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PurchaseHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
商品購入確認ページの作成。
各商品詳細ページの「購入画面に進む」から遷移して、購入できるように。
実際の購入に関しては、サーバーサイド側で実装。
[ページサンプル](https://gyazo.com/6b24e0873c95ee5ac5ca1f001977e419)

# Why
商品購入前に購入者の支払情報等を確認できる必要があるため。

