### PR TITLE
該当する商品が無い場合のページの作成

### DIFF
--- a/app/assets/stylesheets/modules/merchadise/sorry.scss
+++ b/app/assets/stylesheets/modules/merchadise/sorry.scss
@@ -1,0 +1,21 @@
+.merchandise-sorry {
+  width: 700px;
+  margin: 40px auto;
+  text-align: center;
+  font-size: 24px;
+  color: #C5C5C5;
+  background: url('https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?28086846') no-repeat;
+  background-size: 100px 120px;
+  background-position: center 20px;
+  line-height: 24px;
+  padding: 160px 0 60px;
+
+  @media screen and (max-width: 768px) {
+    box-sizing: border-box;
+    width: 100%;
+    font-size: 20px;
+    background-size: 75px 85px;
+    line-height: 20px;
+    padding: 120px 0 40px;
+  }
+}

--- a/app/controllers/merchandises_controller.rb
+++ b/app/controllers/merchandises_controller.rb
@@ -6,11 +6,14 @@ class MerchandisesController < ApplicationController
   end
 
   def show
-    @merchandise = Merchandise.find(merchandise_params[:id])
-    @comment = Comment.new()
-    @like = Like.new()
+    begin
+      @merchandise = Merchandise.find(merchandise_params[:id])
+      @comment = Comment.new()
+      @like = Like.new()
+    rescue
+      render :sorry
+    end
   end
-
 
   def merchandise_params
     params.permit(:id)

--- a/app/controllers/merchandises_controller.rb
+++ b/app/controllers/merchandises_controller.rb
@@ -10,7 +10,7 @@ class MerchandisesController < ApplicationController
       @merchandise = Merchandise.find(merchandise_params[:id])
       @comment = Comment.new()
       @like = Like.new()
-    rescue
+    rescue StandardError
       render :sorry
     end
   end

--- a/app/views/merchandises/sorry.html.haml
+++ b/app/views/merchandises/sorry.html.haml
@@ -1,0 +1,10 @@
+= render 'layouts/header_responsive'
+= render 'layouts/header'
+
+.merchandise-sorry
+  該当する商品は削除されています
+
+-# アプリダウンロードバーナー
+= render 'layouts/app-download'
+-# フッター
+= render 'layouts/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,10 @@ Rails.application.routes.draw do
   end
   resources :exhibit, only: [:index]
 
-  get '/mypage/profile', to: 'mypage#edit'
-  get '/mypage/identification', to: 'mypage#new'
-  get '/mypage/card', to: 'mypage#show'
-  get '/mypage/card/create', to: 'mypage#create'
+  get '/mypage/profile' => 'mypage#edit'
+  get '/mypage/identification' => 'mypage#new'
+  get '/mypage/card' => 'mypage#show'
+  get '/mypage/card/create' => 'mypage#create'
 
   get 'log_in' => 'login#log_in'
   get 'sign_up_before' => 'signup#sign_up_before'

--- a/spec/controllers/merchandises_controller_spec.rb
+++ b/spec/controllers/merchandises_controller_spec.rb
@@ -18,4 +18,18 @@ describe MerchandisesController, type: :controller do
     end
   end
 
+  describe 'GET #show' do
+    it 'DBに登録されている商品の商品詳細のページに遷移できる' do
+      merchandise = create(:merchandise, delivery: delivery, brand: brand, category: category)
+      get :show, params: { id: merchandise }
+      expect(response).to render_template :show
+    end
+
+    it 'DBに登録されていない商品の商品詳細ページに遷移しようとした際に、sorryページへ遷移する' do
+      merchandise = create(:merchandise, delivery: delivery, brand: brand, category: category)
+      get :show, params: { id: merchandise.id + 1 }
+      expect(response).to render_template :sorry
+    end
+  end
+
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 describe Comment do
   describe '#create' do
     it 'コメントの中身がなければ投稿できない(commentがnot null)' do
-      expect {create(:comment, comment: nil)}.to raise_error(ActiveRecord::NotNullViolation)
+      comment = build(:comment, comment: nil)
+      comment.valid?
+      expect(comment.errors[:comment]).to include("can't be blank")
     end
 
     it 'ログインしなければ、コメントできない(user_idがnot null)' do


### PR DESCRIPTION
# What
商品詳細ページを表示する際に、DBに存在しないidを指定した際に遷移する画面の作成。
[画面サンプル](https://gyazo.com/ac9d5630385040ef918ac572c33189c1)

# Why
商品詳細ページを表示する際に、削除済みの商品や存在しないIDのURLを表示したときのエラー画面を回避するため。